### PR TITLE
bug/#44/네브바 상태 변경 문제 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "node server.js",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/src/app/_services/auth-provider.tsx
+++ b/src/app/_services/auth-provider.tsx
@@ -44,7 +44,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   // 내 정보 쿼리
-  const { data: user } = useMyProfile();
+  const { data: user } = useMyProfile(token);
 
   // 로그인 함수
   const login = (newToken: string) => {
@@ -85,10 +85,11 @@ export function useAuth() {
   return context;
 }
 
-export function useMyProfile() {
+export function useMyProfile(token?: string) {
   return useQuery<User>({
-    queryKey: ['myProfile'],
+    queryKey: ['myProfile', token],
     queryFn: getMyProfile,
+    enabled: !!token,
     staleTime: 5 * 60 * 1000,
   });
 }

--- a/src/app/_services/auth-provider.tsx
+++ b/src/app/_services/auth-provider.tsx
@@ -85,7 +85,7 @@ export function useAuth() {
   return context;
 }
 
-export function useMyProfile(token?: string) {
+export function useMyProfile(token?: string | null) {
   return useQuery<User>({
     queryKey: ['myProfile', token],
     queryFn: getMyProfile,


### PR DESCRIPTION
## 📌 PR 제목

[bug] #44 - 네브바 상태 변경 문제 해결

## ✨ 변경 사항

로그인 후 토큰이 바뀌었지만, useMyProfile 쿼리가 토큰 변화를 제대로 감지하지 못해 NavBar는 여전히 "로그인" 상태로 남아있었습니다. 이를 해결하기 위해 queryKey에 token을 포함시켜
토큰이 바뀔 때마다 쿼리가 새로 실행되도록 했습니다.

- [x] useMyProfile 훅에 token 파라미터 추가
 ```js
export function useMyProfile(token?: string | null) {
  return useQuery<User>({
    queryKey: ['myProfile', token], // 2️⃣ queryKey에 token 포함
    queryFn: getMyProfile,
    enabled: !!token, // 3️⃣ token이 있을 때만 쿼리 실행
    staleTime: 5 * 60 * 1000,
  });
}
```
- [x] AuthProvider에서 token 전달
```js
const { data: user } = useMyProfile(token);
``` 

## 🧐 PR 체크리스트

- [x] 코딩 스타일을 따랐나요?
- [x] 관련 이슈를 연결했나요?
- [x] 리뷰어가 이해할 수 있도록 설명을 작성했나요?

## 📷 스크린샷 (선택 사항)

<img width="265" alt="image" src="https://github.com/user-attachments/assets/0bd6c6a8-fc03-44cd-916c-8e57b9caa009" />


## 🚀 관련 이슈

Closes #44 
